### PR TITLE
Update Nargo.toml

### DIFF
--- a/Nargo.toml
+++ b/Nargo.toml
@@ -1,7 +1,8 @@
 [package]
-name = "noir-array-helpers"
+name = "noir_array_helpers"
 authors = ["@colinnielsen"]
 compiler_version = "0.6.0"
 notes = "AMDG"
+type = "lib"
 
 [dependencies]


### PR DESCRIPTION
Fix for this error.

```
Error: Invalid package name `noir-array-helpers` found in /home/josh/nargo/github.com/colinnielsen/noir-array-helpersv0.1.0/Nargo.toml

Location:
    crates/nargo_cli/src/cli/mod.rs:79:5
```

This is using noir v 0.10.3.

I replaced the dashes with underscores and it worked.