### PR TITLE
build: update ci Noir versions

### DIFF
--- a/.github/workflows/noir.yml
+++ b/.github/workflows/noir.yml
@@ -17,9 +17,9 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install Nargo
-        uses: noir-lang/noirup@v0.1.2
+        uses: noir-lang/noirup@v0.1.3
         with:
-          toolchain: v0.10.1
+          toolchain: v0.19.0
 
       - name: Run nargo test
         run: |


### PR DESCRIPTION
Update CI versions of noirup and noir to match dependencies.

Strangely, because Noir compilers <0.19.0 didn't even check the `compiler_version` field, the existing CI pipeline ran fine even though this should have theoretically failed 🤪