### PR TITLE
u64 << u8 mismatch fix

### DIFF
--- a/src/lib.nr
+++ b/src/lib.nr
@@ -4,14 +4,14 @@ pub fn u8_32s_to_u64_16(arr_a: [u8; 32], arr_b: [u8; 32]) -> [u64; 16] {
     for i in 0..4 {
         let mut value: u64 = 0;
         for j in 0..8 {
-            value |= (arr_a[i * 8 + j] as u64) << ((56 - j * 8) as u8);
+            value |= (arr_a[i * 8 + j] as u64) << (56u64 - (j as u64) * 8u64);
         }
         combined_u64[i] = value;
     }
     for i in 4..8 {
         let mut value: u64 = 0;
         for j in 0..8 {
-            value |= (arr_b[(i - 4) * 8 + j] as u64) << ((56 - j * 8) as u8);
+            value |= (arr_b[(i - 4) * 8 + j] as u64) << (56u64 - (j as u64) * 8u64);
         }
         combined_u64[i] = value;
     }


### PR DESCRIPTION
Since Noir is strict when it comes to bit width unlike rust

suggesting a change where the LHS and RHS is of the same bit width similar to the bit width of the return type

p.s. RHS conversion is done in big endian format where the and filled upto the first 8 positions remaining will stay 0