### PR TITLE
fix: cast shift amounts to u64 to match bit width

### DIFF
--- a/src/lib.nr
+++ b/src/lib.nr
@@ -4,14 +4,14 @@ pub fn u8_32s_to_u64_16(arr_a: [u8; 32], arr_b: [u8; 32]) -> [u64; 16] {
     for i in 0..4 {
         let mut value: u64 = 0;
         for j in 0..8 {
-            value |= (arr_a[i * 8 + j] as u64) << ((56 - j * 8) as u8);
+            value |= (arr_a[i * 8 + j] as u64) << ((56 - j * 8) as u64);
         }
         combined_u64[i] = value;
     }
     for i in 4..8 {
         let mut value: u64 = 0;
         for j in 0..8 {
-            value |= (arr_b[(i - 4) * 8 + j] as u64) << ((56 - j * 8) as u8);
+            value |= (arr_b[(i - 4) * 8 + j] as u64) << ((56 - j * 8) as u64);
         }
         combined_u64[i] = value;
     }


### PR DESCRIPTION
### Hi 👋,

### I was trying to use this library with the latest version of Noir and ran into a compilation error:

`error: Integers must have the same bit width LHS is 64, RHS is 8`


I found out that this happens because some shift operations use u8 as the shift amount, while the value being shifted is a u64. In current Noir versions, both sides of a shift must have the same bit width. So, I tried to update something.

###  What I changed

Updated the shift amount casts from `u8 `to `u64 `in `lib.nr`:

`value |= (arr_a[i * 8 + j] as u64) << ((56 - j * 8) as u64);
``value |= (arr_b[(i - 4) * 8 + j] as u64) << ((56 - j * 8) as u64);
`
### Reasoning

- Both the shifted value and the shift amount must have the same bit width in Noir.

- Since value is a u64, the shift amount also needs to be u64.

- This aligns with Noir’s strict typing rules and prevents compilation errors.

Thanks for maintaining this repo! 🙏