### PR TITLE
fix: cast shift amount to u64 for Noir compatibility

### DIFF
--- a/src/lib.nr
+++ b/src/lib.nr
@@ -4,14 +4,14 @@ pub fn u8_32s_to_u64_16(arr_a: [u8; 32], arr_b: [u8; 32]) -> [u64; 16] {
     for i in 0..4 {
         let mut value: u64 = 0;
         for j in 0..8 {
-            value |= (arr_a[i * 8 + j] as u64) << ((56 - j * 8) as u8);
+            value |= (arr_a[i * 8 + j] as u64) << ((56 - j * 8) as u64);
         }
         combined_u64[i] = value;
     }
     for i in 4..8 {
         let mut value: u64 = 0;
         for j in 0..8 {
-            value |= (arr_b[(i - 4) * 8 + j] as u64) << ((56 - j * 8) as u8);
+            value |= (arr_b[(i - 4) * 8 + j] as u64) << ((56 - j * 8) as u64);
         }
         combined_u64[i] = value;
     }


### PR DESCRIPTION
## Problem
Noir now requires both operands of bitwise shift operators (`<<`, `>>`) to have the same bit width. The current code casts the shift amount to `u8`, causing a compilation error:

```bash
error: Integers must have the same bit width LHS is 64, RHS is 8
  ┌─ /home/jistro/nargo/github.com/colinnielsen/noir-array-helpers/v0.30.4/src/lib.nr:7:22
  │
7 │             value |= (arr_a[i * 8 + j] as u64) << ((56 - j * 8) as u8);
  │                      -------------------------------------------------
  │

error: Integers must have the same bit width LHS is 64, RHS is 8
   ┌─ /home/jistro/nargo/github.com/colinnielsen/noir-array-helpers/v0.30.4/src/lib.nr:14:22
   │
14 │             value |= (arr_b[(i - 4) * 8 + j] as u64) << ((56 - j * 8) as u8);
   │                      -------------------------------------------------------
   │

Aborting due to 2 previous errors
```
## Solution
Cast the shift amount to `u64` instead of `u8` in:
- `u8_32s_to_u64_16()` (lines 7 and 14)